### PR TITLE
add underscore version regexp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.32.0
 	github.com/peterbourgon/ff v1.7.1
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.9.0
 	github.com/traefik/traefik/v2 v2.11.0
 	golang.org/x/text v0.17.0
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
@@ -67,6 +68,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/internal/controller/ogcapi_controller.go
+++ b/internal/controller/ogcapi_controller.go
@@ -459,7 +459,7 @@ func (r *OGCAPIReconciler) mutateIngressRoute(ogcAPI *pdoknlv1alpha1.OGCAPI, ing
 		Routes: []traefikiov1alpha1.Route{
 			{
 				Kind:  "Rule",
-				Match: createIngressRuleMatchFromURL(*ogcAPI.Spec.Service.BaseURL.URL, true),
+				Match: createIngressRuleMatchFromURL(*ogcAPI.Spec.Service.BaseURL.URL, true, true),
 				Services: []traefikiov1alpha1.Service{
 					{
 						LoadBalancerSpec: traefikiov1alpha1.LoadBalancerSpec{

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -20,67 +20,67 @@ func Test_createIngressRuleMatchFromURL(t *testing.T) {
 	}{{
 		name: "no path",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my"),
+			url:                     mustURLParse(t, "http://example.com"),
 			includeLocalhost:        false,
 			matchUnderscoreVersions: false,
 		},
-		want: "Host(`host.my`) && PathPrefix(``)",
+		want: "Host(`example.com`) && PathPrefix(``)",
 	}, {
 		name: "include localhost",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my"),
+			url:                     mustURLParse(t, "http://example.com"),
 			includeLocalhost:        true,
 			matchUnderscoreVersions: false,
 		},
-		want: "(Host(`localhost`) || Host(`host.my`)) && PathPrefix(``)",
+		want: "(Host(`localhost`) || Host(`example.com`)) && PathPrefix(``)",
 	}, {
 		name: "no versions",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my/some/path"),
+			url:                     mustURLParse(t, "http://example.com/some/path"),
 			includeLocalhost:        false,
 			matchUnderscoreVersions: false,
 		},
-		want: "Host(`host.my`) && PathPrefix(`/some/path`)",
+		want: "Host(`example.com`) && PathPrefix(`/some/path`)",
 	}, {
 		name: "v1, no replacing",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my/some/path/v1"),
+			url:                     mustURLParse(t, "http://example.com/some/path/v1"),
 			includeLocalhost:        false,
 			matchUnderscoreVersions: false,
 		},
-		want: "Host(`host.my`) && PathPrefix(`/some/path/v1`)",
+		want: "Host(`example.com`) && PathPrefix(`/some/path/v1`)",
 	}, {
 		name: "v1",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my/some/path/v1"),
+			url:                     mustURLParse(t, "http://example.com/some/path/v1"),
 			includeLocalhost:        false,
 			matchUnderscoreVersions: true,
 		},
-		want: "Host(`host.my`) && PathRegexp(`^/some/path/v1(_\\d+)?$`)",
+		want: "Host(`example.com`) && PathRegexp(`^/some/path/v1(_\\d+)?$`)",
 	}, {
 		name: "v2, followed by other segment",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my/some/path/v2/foo"),
+			url:                     mustURLParse(t, "http://example.com/some/path/v2/foo"),
 			includeLocalhost:        false,
 			matchUnderscoreVersions: true,
 		},
-		want: "Host(`host.my`) && PathRegexp(`^/some/path/v2(_\\d+)?/foo$`)",
+		want: "Host(`example.com`) && PathRegexp(`^/some/path/v2(_\\d+)?/foo$`)",
 	}, {
 		name: "v1_3",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my/some/path/v1_3"),
+			url:                     mustURLParse(t, "http://example.com/some/path/v1_3"),
 			includeLocalhost:        false,
 			matchUnderscoreVersions: true,
 		},
-		want: "Host(`host.my`) && PathRegexp(`^/some/path/v1(_3)?$`)",
+		want: "Host(`example.com`) && PathRegexp(`^/some/path/v1(_3)?$`)",
 	}, {
 		name: "combined (never happens)",
 		args: args{
-			url:                     mustURLParse(t, "http://host.my/some/path/v345/v666_78"),
+			url:                     mustURLParse(t, "http://example.com/some/path/v345/v666_78"),
 			includeLocalhost:        false,
 			matchUnderscoreVersions: true,
 		},
-		want: "Host(`host.my`) && PathRegexp(`^/some/path/v345(_\\d+)?/v666(_78)?$`)",
+		want: "Host(`example.com`) && PathRegexp(`^/some/path/v345(_\\d+)?/v666(_78)?$`)",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controller/util_test.go
+++ b/internal/controller/util_test.go
@@ -1,0 +1,98 @@
+package controller
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_createIngressRuleMatchFromURL(t *testing.T) {
+	type args struct {
+		url                     url.URL
+		includeLocalhost        bool
+		matchUnderscoreVersions bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "no path",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my"),
+			includeLocalhost:        false,
+			matchUnderscoreVersions: false,
+		},
+		want: "Host(`host.my`) && PathPrefix(``)",
+	}, {
+		name: "include localhost",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my"),
+			includeLocalhost:        true,
+			matchUnderscoreVersions: false,
+		},
+		want: "(Host(`localhost`) || Host(`host.my`)) && PathPrefix(``)",
+	}, {
+		name: "no versions",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my/some/path"),
+			includeLocalhost:        false,
+			matchUnderscoreVersions: false,
+		},
+		want: "Host(`host.my`) && PathPrefix(`/some/path`)",
+	}, {
+		name: "v1, no replacing",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my/some/path/v1"),
+			includeLocalhost:        false,
+			matchUnderscoreVersions: false,
+		},
+		want: "Host(`host.my`) && PathPrefix(`/some/path/v1`)",
+	}, {
+		name: "v1",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my/some/path/v1"),
+			includeLocalhost:        false,
+			matchUnderscoreVersions: true,
+		},
+		want: "Host(`host.my`) && PathRegexp(`^/some/path/v1(_\\d+)?$`)",
+	}, {
+		name: "v2, followed by other segment",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my/some/path/v2/foo"),
+			includeLocalhost:        false,
+			matchUnderscoreVersions: true,
+		},
+		want: "Host(`host.my`) && PathRegexp(`^/some/path/v2(_\\d+)?/foo$`)",
+	}, {
+		name: "v1_3",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my/some/path/v1_3"),
+			includeLocalhost:        false,
+			matchUnderscoreVersions: true,
+		},
+		want: "Host(`host.my`) && PathRegexp(`^/some/path/v1(_3)?$`)",
+	}, {
+		name: "combined (never happens)",
+		args: args{
+			url:                     mustURLParse(t, "http://host.my/some/path/v345/v666_78"),
+			includeLocalhost:        false,
+			matchUnderscoreVersions: true,
+		},
+		want: "Host(`host.my`) && PathRegexp(`^/some/path/v345(_\\d+)?/v666(_78)?$`)",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createIngressRuleMatchFromURL(tt.args.url, tt.args.includeLocalhost, tt.args.matchUnderscoreVersions); got != tt.want {
+				t.Errorf("createIngressRuleMatchFromURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func mustURLParse(t *testing.T, in string) url.URL {
+	parsed, err := url.Parse(in)
+	require.NoError(t, err)
+	return *parsed
+}


### PR DESCRIPTION
# Description

add underscore version regexp to ingress rule
to support both `v1` and `v1_0`

PDOK-16956

## Type of change

- New feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR