### PR TITLE
gebruik pdok.nl als label prefix+validatie

### DIFF
--- a/api/v1alpha1/ogcapi_webhook.go
+++ b/api/v1alpha1/ogcapi_webhook.go
@@ -124,6 +124,8 @@ func (v *OGCAPICustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj
 	}
 
 	smoothoperatorvalidation.ValidateIngressRouteURLsNotRemoved(oldOgcapi.Spec.IngressRouteURLs, newOgcapi.Spec.IngressRouteURLs, &allErrs, nil)
+
+	smoothoperatorvalidation.ValidateLabelsOnUpdate(oldOgcapi.GetLabels(), newOgcapi.GetLabels(), &allErrs)
 	if len(allErrs) > 0 {
 		return nil, allErrs.ToAggregate()
 	}

--- a/internal/controller/ogcapi_controller.go
+++ b/internal/controller/ogcapi_controller.go
@@ -62,7 +62,7 @@ import (
 
 const (
 	controllerName      = "ogcapi-controller"
-	appLabelKey         = "app"
+	appLabelKey         = "pdok.nl/app"
 	gokoalaName         = "gokoala"
 	configName          = "config"
 	configFileName      = "config.yaml"
@@ -243,8 +243,7 @@ func getBareDeployment(ogcAPI metav1.Object) *appsv1.Deployment {
 
 //nolint:funlen
 func (r *OGCAPIReconciler) mutateDeployment(ogcAPI *pdoknlv1alpha1.OGCAPI, deployment *appsv1.Deployment, configMapName string) error {
-	labels := cloneOrEmptyMap(ogcAPI.GetLabels())
-	labels[appLabelKey] = gokoalaName
+	labels := getLabels(ogcAPI)
 	if err := setImmutableLabels(r.Client, deployment, labels); err != nil {
 		return err
 	}
@@ -368,8 +367,7 @@ func getBareConfigMap(ogcAPI metav1.Object) *corev1.ConfigMap {
 }
 
 func (r *OGCAPIReconciler) mutateConfigMap(ogcAPI *pdoknlv1alpha1.OGCAPI, configMap *corev1.ConfigMap) error {
-	labels := cloneOrEmptyMap(ogcAPI.GetLabels())
-	labels[appLabelKey] = gokoalaName
+	labels := getLabels(ogcAPI)
 	if err := setImmutableLabels(r.Client, configMap, labels); err != nil {
 		return err
 	}
@@ -400,9 +398,7 @@ func getBareService(ogcAPI metav1.Object) *corev1.Service {
 }
 
 func (r *OGCAPIReconciler) mutateService(ogcAPI *pdoknlv1alpha1.OGCAPI, service *corev1.Service) error {
-	labels := cloneOrEmptyMap(ogcAPI.GetLabels())
-	selector := cloneOrEmptyMap(ogcAPI.GetLabels())
-	selector[appLabelKey] = gokoalaName
+	labels := getLabels(ogcAPI)
 	if err := setImmutableLabels(r.Client, service, labels); err != nil {
 		return err
 	}
@@ -424,7 +420,7 @@ func (r *OGCAPIReconciler) mutateService(ogcAPI *pdoknlv1alpha1.OGCAPI, service 
 				TargetPort: intstr.FromInt32(mainPortNr),
 			},
 		},
-		Selector: selector,
+		Selector: labels,
 	}
 	if err := ensureSetGVK(r.Client, service, service); err != nil {
 		return err
@@ -444,7 +440,7 @@ func getBareIngressRoute(ogcAPI metav1.Object) *traefikiov1alpha1.IngressRoute {
 func (r *OGCAPIReconciler) mutateIngressRoute(ogcAPI *pdoknlv1alpha1.OGCAPI, ingressRoute *traefikiov1alpha1.IngressRoute) error {
 	uptimeURL := ogcAPI.Spec.Service.BaseURL.String() + "/health"
 	name := ingressRoute.GetName()
-	labels := cloneOrEmptyMap(ogcAPI.GetLabels())
+	labels := getLabels(ogcAPI)
 	if err := setImmutableLabels(r.Client, ingressRoute, labels); err != nil {
 		return err
 	}
@@ -510,7 +506,7 @@ func getBareStripPrefixMiddleware(ogcAPI metav1.Object) *traefikiov1alpha1.Middl
 }
 
 func (r *OGCAPIReconciler) mutateStripPrefixMiddleware(ogcAPI *pdoknlv1alpha1.OGCAPI, middleware *traefikiov1alpha1.Middleware) error {
-	labels := cloneOrEmptyMap(ogcAPI.GetLabels())
+	labels := getLabels(ogcAPI)
 	if err := setImmutableLabels(r.Client, middleware, labels); err != nil {
 		return err
 	}
@@ -538,8 +534,8 @@ func getBareHeadersMiddleware(obj metav1.Object) *traefikiov1alpha1.Middleware {
 	}
 }
 
-func (r *OGCAPIReconciler) mutateHeadersMiddleware(obj metav1.Object, middleware *traefikiov1alpha1.Middleware, csp string) error {
-	labels := cloneOrEmptyMap(obj.GetLabels())
+func (r *OGCAPIReconciler) mutateHeadersMiddleware(ogcAPI metav1.Object, middleware *traefikiov1alpha1.Middleware, csp string) error {
+	labels := getLabels(ogcAPI)
 	if err := setImmutableLabels(r.Client, middleware, labels); err != nil {
 		return err
 	}
@@ -576,7 +572,7 @@ func (r *OGCAPIReconciler) mutateHeadersMiddleware(obj metav1.Object, middleware
 	if err := ensureSetGVK(r.Client, middleware, middleware); err != nil {
 		return err
 	}
-	return ctrl.SetControllerReference(obj, middleware, r.Scheme)
+	return ctrl.SetControllerReference(ogcAPI, middleware, r.Scheme)
 }
 
 func getBareHorizontalPodAutoscaler(ogcAPI metav1.Object) *autoscalingv2.HorizontalPodAutoscaler {
@@ -589,7 +585,7 @@ func getBareHorizontalPodAutoscaler(ogcAPI metav1.Object) *autoscalingv2.Horizon
 }
 
 func (r *OGCAPIReconciler) mutateHorizontalPodAutoscaler(ogcAPI metav1.Object, hpa *autoscalingv2.HorizontalPodAutoscaler) error {
-	labels := cloneOrEmptyMap(ogcAPI.GetLabels())
+	labels := getLabels(ogcAPI)
 	if err := setImmutableLabels(r.Client, hpa, labels); err != nil {
 		return err
 	}

--- a/internal/controller/testdata/expected/full/ingressroute.yaml
+++ b/internal/controller/testdata/expected/full/ingressroute.yaml
@@ -1,7 +1,8 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  labels: {}
+  labels:
+    pdok.nl/app: gokoala
   annotations:
     uptime.pdok.nl/id: 92dcf547053bcfd16136aba36f3ddddf13cd07f7
     uptime.pdok.nl/name: test title 0.0.0 OGC API

--- a/internal/controller/testdata/expected/minimal/ingressroute.yaml
+++ b/internal/controller/testdata/expected/minimal/ingressroute.yaml
@@ -1,7 +1,8 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  labels: {}
+  labels:
+    pdok.nl/app: gokoala
   annotations:
     uptime.pdok.nl/id: 92dcf547053bcfd16136aba36f3ddddf13cd07f7
     uptime.pdok.nl/name: test title 0.0.0 OGC API

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"maps"
 	"net/url"
 	"regexp"
@@ -82,6 +83,12 @@ func finalizeIfNecessary(ctx context.Context, c client.Client, obj client.Object
 	controllerutil.RemoveFinalizer(obj, finalizerName)
 	err = c.Update(ctx, obj)
 	return false, err
+}
+
+func getLabels(ogcAPI metav1.Object) map[string]string {
+	labels := cloneOrEmptyMap(ogcAPI.GetLabels())
+	labels[appLabelKey] = gokoalaName
+	return labels
 }
 
 func setImmutableLabels(c client.Client, obj client.Object, labels map[string]string) error {


### PR DESCRIPTION
# Description

- the app label now has the pdok.nl prefix
- pdok.nl/app is now set on every generated resource
- label immutability is now checked during validation

## Type of change

(Remove irrelevant options)

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR