### PR TITLE
ogcapi operator te veel pods

### DIFF
--- a/internal/controller/ogcapi_controller.go
+++ b/internal/controller/ogcapi_controller.go
@@ -261,11 +261,11 @@ func (r *OGCAPIReconciler) mutateDeployment(ogcAPI *pdoknlv1alpha1.OGCAPI, deplo
 	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 		Type: appsv1.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &appsv1.RollingUpdateDeployment{
-			MaxUnavailable: intOrStrStrPtr("25%"),
-			MaxSurge:       intOrStrStrPtr("25%"),
+			MaxUnavailable: intOrStrStrPtr("1"),
+			MaxSurge:       intOrStrStrPtr("1"),
 		},
 	}
-	deployment.Spec.RevisionHistoryLimit = int32Ptr(3)
+	deployment.Spec.RevisionHistoryLimit = int32Ptr(1)
 
 	// deployment.Spec.Replicas is controlled by the HPA
 	// deployment.Spec.Paused is ignored to allow a manual intervention i.c.e.

--- a/internal/controller/ogcapi_controller.go
+++ b/internal/controller/ogcapi_controller.go
@@ -261,8 +261,8 @@ func (r *OGCAPIReconciler) mutateDeployment(ogcAPI *pdoknlv1alpha1.OGCAPI, deplo
 	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 		Type: appsv1.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &appsv1.RollingUpdateDeployment{
-			MaxUnavailable: intOrStrStrPtr("1"),
-			MaxSurge:       intOrStrStrPtr("1"),
+			MaxUnavailable: intOrStrIntPtr(1),
+			MaxSurge:       intOrStrIntPtr(1),
 		},
 	}
 	deployment.Spec.RevisionHistoryLimit = int32Ptr(1)

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -244,8 +244,8 @@ func int32Ptr(i int32) *int32 {
 	return &i
 }
 
-func intOrStrStrPtr(s string) *intstr.IntOrString {
-	v := intstr.FromString(s)
+func intOrStrIntPtr(i int32) *intstr.IntOrString {
+	v := intstr.FromInt32(i)
 	return &v
 }
 


### PR DESCRIPTION
# Description

MaxUnavailable aangepast van 25% naar 1. Vanwege afronding wordt er bij niet startende pods pas bij 4 pods toegestaan dat er 1 unavailable is, waardoor bij een onjuiste config er vermoedelijk altijd op z'n minst wordt opgeschaald naar 4 pods. RevisionHistory aangepast en MaxSurge altijd naar 1 (25% wordt altijd afgerond naar 1 bij max 4 replicas)

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR