### PR TITLE
fix: seperate checks for continuing and error

### DIFF
--- a/internal/controller/ogcapi_controller.go
+++ b/internal/controller/ogcapi_controller.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/PDOK/ogcapi-operator/internal/integrations/slack"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +74,8 @@ const (
 	priorityAnnotation  = "priority.version-checker.io"
 
 	volumeMountPath = "/data"
+
+	requeueInterval = time.Second
 )
 
 var (
@@ -127,8 +130,12 @@ func (r *OGCAPIReconciler) Reconcile(ctx context.Context, req controllerruntime.
 		lgr.Info("deleting resources", "name", fullName)
 		return r.deleteAll(ctx, ogcAPI)
 	})
-	if !shouldContinue || err != nil {
+	if err != nil {
+		r.logAndUpdateStatusError(ctx, ogcAPI, err)
 		return result, err
+	}
+	if !shouldContinue {
+		return controllerruntime.Result{RequeueAfter: requeueInterval}, nil
 	}
 
 	operationResults, err := r.createOrUpdate(ctx, ogcAPI)


### PR DESCRIPTION
# Description

Changed error handling to be separate of a check to see if the operator should continue it's Reconcile-loop. If not, we requeue, to make sure

## Type of change
- Bugfix


# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR